### PR TITLE
Remove origin remote before push

### DIFF
--- a/git-resync
+++ b/git-resync
@@ -92,6 +92,7 @@ tmpdir="$( mktemp -d )"
 trap "rm -rf '$tmpdir'" EXIT
 
 git clone --mirror "$source" "$tmpdir"
+git -C "$tmpdir" remote remove origin
 git -C "$tmpdir" remote add destination "$destination"
 
 pushargs=('--all')


### PR DESCRIPTION
When mirroring from GitHub to GitLab, you may encounter an error like the following:
```
 ! [remote rejected] origin/pr/1 -> origin/pr/1 (deny updating a hidden ref)
```
By removing the `origin` remote immediately after cloning, the problematic refs are dropped in the local repo.